### PR TITLE
HBChartで使用している都道府県データをcountでsort

### DIFF
--- a/components/HBChart.vue
+++ b/components/HBChart.vue
@@ -6,13 +6,29 @@ export default {
   extends: HorizontalBar,
   data () {
     return {
-      prefs,
-      prefsName: [],
-      prefsCount: []
+      prefs
+    }
+  },
+  computed: {
+    sortedPref () {
+      return prefs.sort((a, b) => {
+        if (a.count > b.count) {
+          return -1
+        }
+        if (a.count < b.count) {
+          return 1
+        }
+        return 0
+      })
+    },
+    prefsName () {
+      return this.sortedPref.map(pref => pref.name)
+    },
+    prefsCount () {
+      return this.sortedPref.map(pref => pref.count)
     }
   },
   mounted () {
-    this.setData()
     this.renderChart(
       {
         labels: this.prefsName,
@@ -29,18 +45,6 @@ export default {
         maintainAspectRatio: false
       }
     )
-  },
-  methods: {
-    setData () {
-      const prefsName = []
-      const prefsCount = []
-      Object.keys(prefs).forEach(function (key) {
-        prefsName.push(prefs[key].name)
-        prefsCount.push(prefs[key].count)
-      })
-      this.prefsName = prefsName
-      this.prefsCount = prefsCount
-    }
   }
 }
 </script>


### PR DESCRIPTION
## 内容
Chart画面で表示しているvue-chartjsで使用する都道府県データの値をcountでsortするようにしました。

## スクリーンショット
| before | after |
|:--|:--|
| <img width="954" alt="スクリーンショット 2020-04-16 23 38 46" src="https://user-images.githubusercontent.com/548508/79469846-a7829480-803b-11ea-9ba2-ec6dc16c2c18.png"> | <img width="953" alt="スクリーンショット 2020-04-16 23 38 53" src="https://user-images.githubusercontent.com/548508/79469921-bcf7be80-803b-11ea-923e-d0b271596e43.png"> |
