### PR TITLE
バグ2個改修。

### DIFF
--- a/components/HBChart.vue
+++ b/components/HBChart.vue
@@ -11,7 +11,7 @@ export default {
   },
   computed: {
     sortedPref () {
-      return prefs.sort((a, b) => {
+      return prefs.slice().sort((a, b) => {
         if (a.count > b.count) {
           return -1
         }

--- a/pages/bars.vue
+++ b/pages/bars.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container fluid>
-    <chart-component :height="500" />
+    <chart-component :height="1000" />
   </v-container>
 </template>
 


### PR DESCRIPTION
高さが足りなくて、表示されない都道府県が出ていたのを改修。
破壊的なsortになっていたのでslice入れて回避。