### PR TITLE
導入件数・検索ヒット件数の数値をカンマ区切りにする

### DIFF
--- a/components/PrefsIndex.vue
+++ b/components/PrefsIndex.vue
@@ -15,7 +15,10 @@
           color="light-green lighten-4"
           flat
         >
-          <v-toolbar-title>導入数 （{{ importData.totalCount }}件） 最終更新日: {{ importData.updateDate }} </v-toolbar-title>
+          <v-toolbar-title>
+            導入数 （{{ importData.totalCount.toLocaleString() }}件）
+            最終更新日: {{ importData.updateDate }}
+          </v-toolbar-title>
           <template>
             <v-spacer />
             <v-btn-toggle

--- a/components/Search.vue
+++ b/components/Search.vue
@@ -7,7 +7,7 @@
     >
       <v-toolbar-title>
         検索ヒット数 （<b v-model="hitCount">
-          {{ hitCount }}
+          {{ hitCount.toLocaleString() }}
         </b>件）
       </v-toolbar-title>
     </v-toolbar>

--- a/components/TotalCountBar.vue
+++ b/components/TotalCountBar.vue
@@ -1,6 +1,9 @@
 <template>
   <v-container fluid>
-    <v-toolbar-title>導入数 （{{ importData.totalCount }}件） 最終更新日: {{ importData.updateDate }} </v-toolbar-title>
+    <v-toolbar-title>
+      導入数 （{{ importData.totalCount.toLocaleString() }}件）
+      最終更新日: {{ importData.updateDate }}
+    </v-toolbar-title>
   </v-container>
 </template>
 <script>


### PR DESCRIPTION
導入件数・検索ヒット件数は4桁, 5桁になるので、数値をカンマ区切りにしました。

<img width="514" alt="スクリーンショット 2020-05-06 15 21 50" src="https://user-images.githubusercontent.com/5081402/81143662-51a36b80-8fad-11ea-87bd-21c9147e8d1e.png">
